### PR TITLE
Minor simplification and fix in relation with `_settings_titles` introduction

### DIFF
--- a/picard/profile.py
+++ b/picard/profile.py
@@ -87,8 +87,8 @@ def profile_groups_values():
         yield _settings_groups[k]
 
 
-def profile_groups_reset():
-    """Used when testing"""
+def profile_groups_initialize():
+    """Initialize profile groups related variables"""
     global _settings_groups, _groups_order, _groups_count, _known_settings
     _settings_groups = {}
     _groups_order = defaultdict(lambda: -1)

--- a/picard/profile.py
+++ b/picard/profile.py
@@ -31,11 +31,7 @@ from collections import (
 
 SettingDesc = namedtuple('SettingDesc', ('name', 'highlights'))
 
-_settings_groups = {}
-_groups_order = defaultdict(lambda: -1)
-_groups_count = 0
-_known_settings = set()
-_settings_titles = {}
+__initialized = False
 
 
 def profile_groups_order(group):
@@ -89,14 +85,19 @@ def profile_groups_values():
 
 def profile_groups_initialize():
     """Initialize profile groups related variables"""
-    global _settings_groups, _groups_order, _groups_count, _known_settings
+    global _settings_groups, _groups_order, _groups_count, _known_settings, _settings_titles
+
     _settings_groups = {}
     _groups_order = defaultdict(lambda: -1)
     _groups_count = 0
     _known_settings = set()
+    _settings_titles = defaultdict(lambda: None)
 
 
 def profile_setting_title(option_name):
-    if option_name not in _settings_titles:
-        return None
     return _settings_titles[option_name]
+
+
+if not __initialized:
+    profile_groups_initialize()
+    __initialized = True

--- a/test/test_profiles.py
+++ b/test/test_profiles.py
@@ -44,6 +44,7 @@ from picard.profile import (
     profile_groups_reset,
     profile_groups_settings,
     profile_groups_values,
+    profile_setting_title,
 )
 
 
@@ -358,3 +359,7 @@ class TestUserProfiles(TestPicardProfilesCommon):
         self.assertEqual(self.config.setting[self.test_setting_3], "def")
         self.config.profiles[self.PROFILES_KEY] = self.get_profiles(enabled=False)
         self.assertEqual(self.config.setting[self.test_setting_3], "abc")
+
+    def test_profile_setting_title(self):
+        self.assertEqual(profile_setting_title('opt1'), "title_group1")
+        self.assertEqual(profile_setting_title('notopt1'), None)

--- a/test/test_profiles.py
+++ b/test/test_profiles.py
@@ -39,9 +39,9 @@ from picard.config import (
 from picard.profile import (
     profile_groups_add_setting,
     profile_groups_all_settings,
+    profile_groups_initialize,
     profile_groups_keys,
     profile_groups_order,
-    profile_groups_reset,
     profile_groups_settings,
     profile_groups_values,
     profile_setting_title,
@@ -73,7 +73,7 @@ class TestPicardProfilesCommon(PicardTestCase):
         Option('profiles', self.SETTINGS_KEY, {})
 
         # Get valid profile option settings for testing
-        profile_groups_reset()
+        profile_groups_initialize()
         for n in range(0, 4):
             group = 'group%d' % (n % 2)
             title = 'title_' + group


### PR DESCRIPTION
Minor changes because since we added `_settings_titles`:

- add test for profile_setting_title()
- rename `profile_groups_reset()` to `profile_groups_initialize()`
- initialize defaults in a method,  it reduce code redundancy and will avoid future errors like this one.