### PR TITLE
Plugin template improvements

### DIFF
--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -58,7 +58,11 @@ from picard.git.utils import (
     get_local_repository_path,
 )
 from picard.options import init_options
-from picard.plugin3.constants import CATEGORIES as VALID_CATEGORIES, LICENSES
+from picard.plugin3.constants import (
+    CATEGORIES as VALID_CATEGORIES,
+    DEFAULT_SOURCE_LOCALE,
+    LICENSES,
+)
 from picard.plugin3.init_templates import (
     get_git_author,
     get_git_config_author,
@@ -1888,7 +1892,7 @@ class PluginCLI:
         with_i18n = getattr(self._args, 'with_translations', False) or self._out.yesno(
             'Include translation support (i18n)?', default='N'
         )
-        source_locale = getattr(self._args, 'source_locale', 'en')
+        source_locale = getattr(self._args, 'source_locale', DEFAULT_SOURCE_LOCALE)
         if with_i18n:
             locale_input = input(f'{self._out.bold("Source locale")} [{self._out.dim(source_locale)}]: ').strip()
             if locale_input:
@@ -1963,7 +1967,7 @@ class PluginCLI:
 
         # Check --source-locale flag
         if source_locale is None:
-            source_locale = getattr(self._args, 'source_locale', 'en')
+            source_locale = getattr(self._args, 'source_locale', DEFAULT_SOURCE_LOCALE)
 
         # Check --no-commit flag
         if git_commit:
@@ -2203,8 +2207,8 @@ def process_cmdline_args():
     group_advanced.add_argument(
         '--source-locale',
         metavar='LOCALE',
-        default='en',
-        help="source locale for --init with --with-translations (default: en)",
+        default=DEFAULT_SOURCE_LOCALE,
+        help=f"source locale for --init with --with-translations (default: {DEFAULT_SOURCE_LOCALE})",
     )
     group_advanced.add_argument(
         '--locale', metavar='LOCALE', default='en', help="locale for displaying plugin info (e.g., 'fr', 'de', 'en')"

--- a/picard/plugin3/cli.py
+++ b/picard/plugin3/cli.py
@@ -1885,6 +1885,15 @@ class PluginCLI:
             'license': license_id,
         }
 
+        with_i18n = getattr(self._args, 'with_translations', False) or self._out.yesno(
+            'Include translation support (i18n)?', default='N'
+        )
+        source_locale = getattr(self._args, 'source_locale', 'en')
+        if with_i18n:
+            locale_input = input(f'{self._out.bold("Source locale")} [{self._out.dim(source_locale)}]: ').strip()
+            if locale_input:
+                source_locale = locale_input
+
         return self._create_plugin_project(
             name,
             description,
@@ -1894,8 +1903,8 @@ class PluginCLI:
             license_url,
             author_email=author_email,
             target=target,
-            with_i18n=getattr(self._args, 'with_translations', False)
-            or self._out.yesno('Include translation support (i18n)?', default='N'),
+            with_i18n=with_i18n,
+            source_locale=source_locale,
             git_commit=not getattr(self._args, 'no_commit', False)
             and self._out.yesno('Create initial git commit?', default='Y'),
         )
@@ -1912,6 +1921,7 @@ class PluginCLI:
         target=None,
         git_commit=True,
         with_i18n=False,
+        source_locale=None,
     ):
         """Create the plugin project directory and files.
 
@@ -1926,6 +1936,7 @@ class PluginCLI:
             target: Explicit target directory (overrides --parent-dir/--target-dir)
             git_commit: Whether to create an initial git commit
             with_i18n: Whether to generate translation-enabled skeleton
+            source_locale: Source locale for translations
 
         Returns:
             ExitCode
@@ -1949,6 +1960,10 @@ class PluginCLI:
         # Check --with-translations flag
         if not with_i18n:
             with_i18n = getattr(self._args, 'with_translations', False)
+
+        # Check --source-locale flag
+        if source_locale is None:
+            source_locale = getattr(self._args, 'source_locale', 'en')
 
         # Check --no-commit flag
         if git_commit:
@@ -1987,6 +2002,7 @@ class PluginCLI:
                 license_url,
                 with_i18n=with_i18n,
                 report_bugs_to=report_bugs_to,
+                source_locale=source_locale,
             )
         except OSError as e:
             self._out.error(f'Failed to create plugin project: {e}')
@@ -2184,6 +2200,12 @@ def process_cmdline_args():
         '--with-translations', action='store_true', help="include translation support (locale files and examples)"
     )
     group_advanced.add_argument('--no-commit', action='store_true', help="skip initial git commit with --init")
+    group_advanced.add_argument(
+        '--source-locale',
+        metavar='LOCALE',
+        default='en',
+        help="source locale for --init with --with-translations (default: en)",
+    )
     group_advanced.add_argument(
         '--locale', metavar='LOCALE', default='en', help="locale for displaying plugin info (e.g., 'fr', 'de', 'en')"
     )

--- a/picard/plugin3/constants.py
+++ b/picard/plugin3/constants.py
@@ -26,6 +26,9 @@ REGISTRY_TRUST_LEVELS = ['official', 'trusted', 'community']
 # Plugin categories
 CATEGORIES = ['metadata', 'coverart', 'ui', 'scripting', 'formats', 'other']
 
+# Default source locale for plugin translations
+DEFAULT_SOURCE_LOCALE = 'en'
+
 # Common SPDX licenses for plugins
 LICENSES = {
     'GPL-2.0-or-later': 'https://www.gnu.org/licenses/gpl-2.0.html',

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import re
 import unicodedata
 
+from picard.plugin3.constants import DEFAULT_SOURCE_LOCALE
 from picard.plugin3.validator import generate_uuid
 
 
@@ -79,7 +80,7 @@ def generate_manifest(
     license_url: str = '',
     with_i18n: bool = False,
     report_bugs_to: str = '',
-    source_locale: str = 'en',
+    source_locale: str = DEFAULT_SOURCE_LOCALE,
     long_description: str = '',
 ) -> str:
     """Generate a filled-in MANIFEST.toml for a new plugin.
@@ -124,7 +125,7 @@ def generate_manifest(
     if long_description:
         lines.append(f'long_description = "{toml_escape(long_description)}"')
     if with_i18n:
-        source_locale = source_locale.strip() or 'en'
+        source_locale = source_locale.strip() or DEFAULT_SOURCE_LOCALE
         other_locale = 'de' if source_locale != 'de' else 'en'  # ensure different from source locale
         lines.append(f'source_locale = "{toml_escape(source_locale)}"')
         lines.append('')
@@ -286,7 +287,7 @@ def write_plugin_project(
     license_url: str = '',
     with_i18n: bool = False,
     report_bugs_to: str = '',
-    source_locale: str = 'en',
+    source_locale: str = DEFAULT_SOURCE_LOCALE,
     long_description: str = '',
 ) -> list[str]:
     """Write plugin scaffold files to target directory.
@@ -309,7 +310,7 @@ def write_plugin_project(
     Returns:
         list: Filenames/dirs created (for display purposes)
     """
-    source_locale = source_locale.strip() or 'en'
+    source_locale = source_locale.strip() or DEFAULT_SOURCE_LOCALE
     target.mkdir(parents=True, exist_ok=True)
     (target / 'MANIFEST.toml').write_text(
         generate_manifest(

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -126,7 +126,7 @@ def generate_manifest(
     if with_i18n:
         source_locale = source_locale.strip() or 'en'
         other_locale = 'de' if source_locale != 'de' else 'en'  # ensure different from source locale
-        lines.append(f'source_locale = "{source_locale}"')
+        lines.append(f'source_locale = "{toml_escape(source_locale)}"')
         lines.append('')
         lines.append('# [name_i18n]')
         lines.append(f'# {other_locale} = ""')

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -286,6 +286,8 @@ def write_plugin_project(
     license_url: str = '',
     with_i18n: bool = False,
     report_bugs_to: str = '',
+    source_locale: str = 'en',
+    long_description: str = '',
 ) -> list[str]:
     """Write plugin scaffold files to target directory.
 
@@ -301,6 +303,8 @@ def write_plugin_project(
         license_url: License URL
         with_i18n: Whether to generate translation-enabled skeleton
         report_bugs_to: Bug tracker URL or mailto: address
+        source_locale: Locale for the source strings
+        long_description: Long description
 
     Returns:
         list: Filenames/dirs created (for display purposes)
@@ -316,6 +320,8 @@ def write_plugin_project(
             license_url,
             with_i18n=with_i18n,
             report_bugs_to=report_bugs_to,
+            source_locale=source_locale,
+            long_description=long_description,
         ),
         encoding='utf-8',
     )

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -309,6 +309,7 @@ def write_plugin_project(
     Returns:
         list: Filenames/dirs created (for display purposes)
     """
+    source_locale = source_locale.strip() or 'en'
     target.mkdir(parents=True, exist_ok=True)
     (target / 'MANIFEST.toml').write_text(
         generate_manifest(
@@ -332,7 +333,7 @@ def write_plugin_project(
     if with_i18n:
         locale_dir = target / 'locale'
         locale_dir.mkdir()
-        locale_filename = (source_locale.strip() or 'en') + '.toml'
+        locale_filename = source_locale + '.toml'
         (locale_dir / locale_filename).write_text(generate_source_locale_toml(), encoding='utf-8')
         filenames.append('locale/')
     return filenames

--- a/picard/plugin3/init_templates.py
+++ b/picard/plugin3/init_templates.py
@@ -332,7 +332,8 @@ def write_plugin_project(
     if with_i18n:
         locale_dir = target / 'locale'
         locale_dir.mkdir()
-        (locale_dir / 'en.toml').write_text(generate_source_locale_toml(), encoding='utf-8')
+        locale_filename = (source_locale.strip() or 'en') + '.toml'
+        (locale_dir / locale_filename).write_text(generate_source_locale_toml(), encoding='utf-8')
         filenames.append('locale/')
     return filenames
 

--- a/picard/plugin3/manifest.py
+++ b/picard/plugin3/manifest.py
@@ -25,7 +25,10 @@ except (ImportError, ModuleNotFoundError):
 
 from typing import BinaryIO
 
-from picard.plugin3.constants import CATEGORIES
+from picard.plugin3.constants import (
+    CATEGORIES,
+    DEFAULT_SOURCE_LOCALE,
+)
 from picard.plugin3.validator import (
     generate_uuid,
     validate_manifest_dict,
@@ -160,7 +163,7 @@ class PluginManifest:
     @property
     def source_locale(self) -> str:
         """Get source locale for translations, defaults to 'en'."""
-        return self._data.get('source_locale', 'en')
+        return self._data.get('source_locale', DEFAULT_SOURCE_LOCALE)
 
     def validate(self) -> list:
         """Validate manifest and return list of errors.

--- a/test/plugins3/helpers.py
+++ b/test/plugins3/helpers.py
@@ -30,6 +30,7 @@ from picard.git.factory import (
 )
 from picard.plugin3.api import PluginApi
 from picard.plugin3.cli import PluginCLI
+from picard.plugin3.constants import DEFAULT_SOURCE_LOCALE
 from picard.plugin3.manager import PluginManager
 from picard.plugin3.manifest import PluginManifest
 from picard.plugin3.output import PluginOutput
@@ -193,7 +194,7 @@ class MockCliArgs(Mock):
             'locale': 'en',
             'with_translations': False,
             'no_commit': False,
-            'source_locale': 'en',
+            'source_locale': DEFAULT_SOURCE_LOCALE,
         }
         defaults.update(kwargs)
         super().__init__(**defaults)

--- a/test/plugins3/helpers.py
+++ b/test/plugins3/helpers.py
@@ -193,6 +193,7 @@ class MockCliArgs(Mock):
             'locale': 'en',
             'with_translations': False,
             'no_commit': False,
+            'source_locale': 'en',
         }
         defaults.update(kwargs)
         super().__init__(**defaults)

--- a/test/plugins3/test_cli.py
+++ b/test/plugins3/test_cli.py
@@ -1410,6 +1410,18 @@ class TestPluginCLIInit(PicardTestCase):
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
         self.assertNotIn('source_locale', manifest)
 
+    def test_init_with_custom_source_locale(self):
+        """--init --with-translations --source-locale creates correct locale file and manifest."""
+        target = self.tmpdir / 'test-plugin'
+        exit_code, stdout, stderr = run_cli(
+            MockPluginManager(), init='Test', target_dir=str(target), with_translations=True, source_locale='fr'
+        )
+        self.assertEqual(ExitCode.SUCCESS, exit_code)
+        manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
+        self.assertIn('source_locale = "fr"', manifest)
+        self.assertTrue((target / 'locale' / 'fr.toml').exists())
+        self.assertFalse((target / 'locale' / 'en.toml').exists())
+
 
 class TestPluginCLIInitInteractive(PicardTestCase):
     """Tests for --init interactive mode."""

--- a/test/plugins3/test_init_templates.py
+++ b/test/plugins3/test_init_templates.py
@@ -147,6 +147,50 @@ class TestGenerateManifest(PicardTestCase):
         data = tomllib.loads(result)
         self.assertEqual(data['name'], "Plugin d'Étiquetage")
 
+    def test_with_source_locale(self):
+        """Custom source_locale is included when i18n is enabled."""
+        result = generate_manifest('Test', with_i18n=True, source_locale='fr')
+        data = tomllib.loads(result)
+        self.assertEqual(data['source_locale'], 'fr')
+
+    def test_source_locale_default(self):
+        """Default source_locale is 'en'."""
+        result = generate_manifest('Test', with_i18n=True)
+        data = tomllib.loads(result)
+        self.assertEqual(data['source_locale'], 'en')
+
+    def test_source_locale_whitespace_fallback(self):
+        """Whitespace-only source_locale falls back to 'en'."""
+        result = generate_manifest('Test', with_i18n=True, source_locale='  ')
+        data = tomllib.loads(result)
+        self.assertEqual(data['source_locale'], 'en')
+
+    def test_other_locale_differs_from_source(self):
+        """i18n example locale differs from source_locale."""
+        result = generate_manifest('Test', with_i18n=True, source_locale='de')
+        self.assertIn('# en = ""', result)
+
+    def test_other_locale_default_is_de(self):
+        """When source_locale is not 'de', example locale is 'de'."""
+        result = generate_manifest('Test', with_i18n=True, source_locale='en')
+        self.assertIn('# de = ""', result)
+
+    def test_with_long_description(self):
+        """long_description produces valid TOML."""
+        result = generate_manifest('Test', long_description='A longer description')
+        data = tomllib.loads(result)
+        self.assertEqual(data['long_description'], 'A longer description')
+
+    def test_long_description_i18n_section(self):
+        """long_description with i18n includes long_description_i18n comment."""
+        result = generate_manifest('Test', long_description='Long desc', with_i18n=True)
+        self.assertIn('# [long_description_i18n]', result)
+
+    def test_no_long_description_i18n_without_long_description(self):
+        """Without long_description, no long_description_i18n section."""
+        result = generate_manifest('Test', with_i18n=True)
+        self.assertNotIn('long_description_i18n', result)
+
 
 class TestGeneratePluginInitPy(PicardTestCase):
     def test_contains_enable(self):


### PR DESCRIPTION
Few improvements:

- Make `generate_manifest()` parameters usable end-to-end,  `source_locale` and `long_description` are now forwarded through `write_plugin_project()` (so the GUI plugin can use this high-level function), and the locale file is named after `source_locale` instead of hardcoded `en.toml.`
- Add` --source-locale` to the CLI — available as a flag for non-interactive mode, prompted in interactive mode when i18n is enabled.
- Cleanup: `toml_escape() `applied to `source_locale`, duplicated normalization logic consolidated, magic 'en' replaced with a `DEFAULT_SOURCE_LOCALE` constant in `picard/plugin3/constants.py`, and test coverage added for all new code paths.
