### PR TITLE
Improvements to Startup options page and Log View

### DIFF
--- a/picard/ui/forms/ui_options_startup.py
+++ b/picard/ui/forms/ui_options_startup.py
@@ -18,7 +18,9 @@ class Ui_StartupOptionsPage(object):
     def setupUi(self, StartupOptionsPage):
         StartupOptionsPage.setObjectName("StartupOptionsPage")
         StartupOptionsPage.resize(403, 373)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(StartupOptionsPage.sizePolicy().hasHeightForWidth())
@@ -27,7 +29,9 @@ class Ui_StartupOptionsPage(object):
         self.vboxlayout.setObjectName("vboxlayout")
         self.update_check_group = QtWidgets.QGroupBox(parent=StartupOptionsPage)
         self.update_check_group.setEnabled(True)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Preferred
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.update_check_group.sizePolicy().hasHeightForWidth())
@@ -54,7 +58,9 @@ class Ui_StartupOptionsPage(object):
         self.horizontalLayout_2 = QtWidgets.QHBoxLayout()
         self.horizontalLayout_2.setObjectName("horizontalLayout_2")
         self.label_2 = QtWidgets.QLabel(parent=self.program_update_check_group)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.MinimumExpanding, QtWidgets.QSizePolicy.Policy.Preferred)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Policy.MinimumExpanding, QtWidgets.QSizePolicy.Policy.Preferred
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.label_2.sizePolicy().hasHeightForWidth())
@@ -67,7 +73,11 @@ class Ui_StartupOptionsPage(object):
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.update_check_days.sizePolicy().hasHeightForWidth())
         self.update_check_days.setSizePolicy(sizePolicy)
-        self.update_check_days.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeading|QtCore.Qt.AlignmentFlag.AlignLeft|QtCore.Qt.AlignmentFlag.AlignVCenter)
+        self.update_check_days.setAlignment(
+            QtCore.Qt.AlignmentFlag.AlignLeading
+            | QtCore.Qt.AlignmentFlag.AlignLeft
+            | QtCore.Qt.AlignmentFlag.AlignVCenter
+        )
         self.update_check_days.setMinimum(1)
         self.update_check_days.setObjectName("update_check_days")
         self.horizontalLayout_2.addWidget(self.update_check_days)
@@ -76,7 +86,9 @@ class Ui_StartupOptionsPage(object):
         self.horizontalLayout_3 = QtWidgets.QHBoxLayout()
         self.horizontalLayout_3.setObjectName("horizontalLayout_3")
         self.label_3 = QtWidgets.QLabel(parent=self.update_check_group)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Preferred)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Preferred
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.label_3.sizePolicy().hasHeightForWidth())
@@ -99,7 +111,9 @@ class Ui_StartupOptionsPage(object):
         self.horizontalLayout_4 = QtWidgets.QHBoxLayout(self.groupBox_3)
         self.horizontalLayout_4.setObjectName("horizontalLayout_4")
         self.log_verbosity_label = QtWidgets.QLabel(parent=self.groupBox_3)
-        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Preferred)
+        sizePolicy = QtWidgets.QSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Preferred
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.log_verbosity_label.sizePolicy().hasHeightForWidth())
@@ -110,7 +124,9 @@ class Ui_StartupOptionsPage(object):
         self.starting_log_level.setObjectName("starting_log_level")
         self.horizontalLayout_4.addWidget(self.starting_log_level)
         self.vboxlayout.addWidget(self.groupBox_3)
-        spacerItem = QtWidgets.QSpacerItem(181, 21, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+        spacerItem = QtWidgets.QSpacerItem(
+            181, 21, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding
+        )
         self.vboxlayout.addItem(spacerItem)
 
         self.retranslateUi(StartupOptionsPage)
@@ -129,4 +145,4 @@ class Ui_StartupOptionsPage(object):
         self.label_2.setText(_("Days between checks:"))
         self.label_3.setText(_("Updates to check:"))
         self.groupBox_3.setTitle(_("Logging"))
-        self.log_verbosity_label.setText(_("Start Picard at log level:"))
+        self.log_verbosity_label.setText(_("Default log level:"))

--- a/picard/ui/logview.py
+++ b/picard/ui/logview.py
@@ -278,6 +278,12 @@ class LogView(LogViewCommon):
         self.verbosity_menu_button = QtWidgets.QPushButton()
         self.verbosity_menu_button.setAutoDefault(False)
         self.verbosity_menu_button.setAccessibleName(_("Verbosity"))
+        self.verbosity_menu_button.setToolTip(
+            _(
+                "Changes the logging verbosity level for the current session. "
+                "The default level configured in Options will be restored on next startup."
+            )
+        )
         self.hbox.addWidget(self.verbosity_menu_button)
 
         self.verbosity_menu = VerbosityMenu()

--- a/picard/ui/options/startup.py
+++ b/picard/ui/options/startup.py
@@ -50,7 +50,7 @@ from picard.ui.options import OptionsPage
 class StartupOptionsPage(OptionsPage):
     NAME = 'startup'
     TITLE = N_("Startup")
-    PARENT = None
+    PARENT = 'general'
     SORT_ORDER = 5
     ACTIVE = True
     HELP_URL = "/config/options_startup.html"

--- a/picard/ui/options/startup.py
+++ b/picard/ui/options/startup.py
@@ -112,9 +112,5 @@ class StartupOptionsPage(OptionsPage):
         config.setting['log_verbosity'] = self.ui.starting_log_level.currentData(QtCore.Qt.ItemDataRole.UserRole)
         log.set_verbosity(config.setting['log_verbosity'])
 
-    def restore_defaults(self):
-        super().restore_defaults()
-        self.logout()
-
 
 register_options_page(StartupOptionsPage)

--- a/ui/options_startup.ui
+++ b/ui/options_startup.ui
@@ -158,7 +158,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Start Picard at log level:</string>
+         <string>Default log level:</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Changes on top of the default_logging_to_info branch:

- Move Startup options page under General (as a child page)
- Add tooltip to Log View verbosity selector explaining session behavior
- Rename label from "Start Picard at log level:" to "Default log level:"
- Remove incorrect restore_defaults/logout from StartupOptionsPage