### PR TITLE
Review fixes for coverart playground

### DIFF
--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -111,7 +111,7 @@ class ProviderOptionsLocal(ProviderOptions):
             line = line.strip()
             fmt = self.fmt_clear
             if line:
-                if coverart_filter.match(line):
+                if coverart_filter.search(line):
                     fmt = self.fmt_match
                 else:
                     fmt = self.fmt_skip

--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -38,10 +38,24 @@ from picard.coverart.providers.provider import (
     ProviderOptions,
 )
 from picard.coverart.utils import CAA_TYPES
-from picard.i18n import N_
+from picard.i18n import (
+    N_,
+    gettext as _,
+)
 
 from picard.ui.forms.ui_provider_options_local import Ui_LocalOptions
 from picard.ui.options import PageOptionConfigs
+
+
+TOOLTIP_TEST_COVERART_FILTER = N_("""<html><head/><body>
+<p>Enter file names to test the regex against, one per line.<br/>
+This playground will not be preserved on exit.
+</p>
+<p>
+Red background means the file name does not match.<br/>
+Green background means the file name matches.
+</p>
+</body></html>""")
 
 
 class ProviderOptionsLocal(ProviderOptions):
@@ -63,6 +77,7 @@ class ProviderOptionsLocal(ProviderOptions):
         self.init_regex_checker(self.ui.local_cover_regex_edit, self.ui.local_cover_regex_error)
 
         self.ui.local_cover_regex_edit.textChanged.connect(self.update_test_coverart_filter)
+        self.ui.test_coverart_filter.setToolTip(_(TOOLTIP_TEST_COVERART_FILTER))
         self.ui.test_coverart_filter.textChanged.connect(self.update_test_coverart_filter)
 
         # FIXME: colors aren't great from accessibility POV

--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -101,8 +101,9 @@ class ProviderOptionsLocal(ProviderOptions):
     def update_test_coverart_filter(self):
         test_text = self.ui.test_coverart_filter.toPlainText()
 
+        regex_text = self.ui.local_cover_regex_edit.text()
         try:
-            coverart_filter = re.compile(self.ui.local_cover_regex_edit.text(), re.IGNORECASE)
+            coverart_filter = re.compile(regex_text, re.IGNORECASE) if regex_text else None
         except re.error:
             coverart_filter = None
 

--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -25,7 +25,6 @@
 import os
 import re
 
-from PyQt6.QtCore import Qt
 from PyQt6.QtGui import (
     QTextBlockFormat,
     QTextCursor,
@@ -43,6 +42,7 @@ from picard.i18n import (
     gettext as _,
 )
 
+from picard.ui.colors import interface_colors
 from picard.ui.forms.ui_provider_options_local import Ui_LocalOptions
 from picard.ui.options import PageOptionConfigs
 
@@ -83,13 +83,20 @@ class ProviderOptionsLocal(ProviderOptions):
 
         # FIXME: colors aren't great from accessibility POV
         self.fmt_match = QTextBlockFormat()
-        self.fmt_match.setBackground(Qt.GlobalColor.green)
+        self.fmt_match.setBackground(self._highlight_color('tagstatus_added'))
 
         self.fmt_skip = QTextBlockFormat()
-        self.fmt_skip.setBackground(Qt.GlobalColor.red)
+        self.fmt_skip.setBackground(self._highlight_color('tagstatus_removed'))
 
         self.fmt_clear = QTextBlockFormat()
         self.fmt_clear.clearBackground()
+
+    @staticmethod
+    def _highlight_color(color_key):
+        alpha = 90 if interface_colors.dark_theme else 60
+        color = interface_colors.get_qcolor(color_key)
+        color.setAlpha(alpha)
+        return color
 
     def load(self):
         config = get_config()

--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -78,6 +78,7 @@ class ProviderOptionsLocal(ProviderOptions):
 
         self.ui.local_cover_regex_edit.textChanged.connect(self.update_test_coverart_filter)
         self.ui.test_coverart_filter.setToolTip(_(TOOLTIP_TEST_COVERART_FILTER))
+        self.ui.test_coverart_filter.setPlaceholderText(_("Enter file names to test, one per line"))
         self.ui.test_coverart_filter.textChanged.connect(self.update_test_coverart_filter)
 
         # FIXME: colors aren't great from accessibility POV

--- a/picard/ui/forms/ui_provider_options_local.py
+++ b/picard/ui/forms/ui_provider_options_local.py
@@ -40,7 +40,9 @@ class Ui_LocalOptions(object):
         self.note.setWordWrap(True)
         self.note.setObjectName("note")
         self.verticalLayout.addWidget(self.note)
-        spacerItem = QtWidgets.QSpacerItem(20, 10, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Fixed)
+        spacerItem = QtWidgets.QSpacerItem(
+            20, 10, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Fixed
+        )
         self.verticalLayout.addItem(spacerItem)
         self.label_test_coverart_filter = QtWidgets.QLabel(parent=LocalOptions)
         self.label_test_coverart_filter.setObjectName("label_test_coverart_filter")
@@ -48,7 +50,9 @@ class Ui_LocalOptions(object):
         self.test_coverart_filter = QtWidgets.QPlainTextEdit(parent=LocalOptions)
         self.test_coverart_filter.setObjectName("test_coverart_filter")
         self.verticalLayout.addWidget(self.test_coverart_filter)
-        spacerItem1 = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+        spacerItem1 = QtWidgets.QSpacerItem(
+            20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding
+        )
         self.verticalLayout.addItem(spacerItem1)
 
         self.retranslateUi(LocalOptions)
@@ -57,5 +61,9 @@ class Ui_LocalOptions(object):
     def retranslateUi(self, LocalOptions):
         LocalOptions.setWindowTitle(_("Form"))
         self.local_cover_regex_label.setText(_("Local cover art files match the following regular expression:"))
-        self.note.setText(_("First group in the regular expression, if any, will be used as type, ie. cover-back-spine.jpg will be set as types Back + Spine. If no type is found, it will default to Front type."))
-        self.label_test_coverart_filter.setText(_("Playground for cover art file matching (cleared on exit):"))
+        self.note.setText(
+            _(
+                "First group in the regular expression, if any, will be used as type, ie. cover-back-spine.jpg will be set as types Back + Spine. If no type is found, it will default to Front type."
+            )
+        )
+        self.label_test_coverart_filter.setText(_("Test file name matching:"))

--- a/ui/provider_options_local.ui
+++ b/ui/provider_options_local.ui
@@ -69,7 +69,7 @@
    <item>
     <widget class="QLabel" name="label_test_coverart_filter">
      <property name="text">
-      <string>Playground for cover art file matching (cleared on exit):</string>
+      <string>Test file name matching:</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Suggested improvements from review of metabrainz/picard#3317:

1. **Bug fix: Use search() instead of match()** — the actual provider uses `re.search()` to match filenames anywhere in the string, but the playground used `re.match()` which only checks from the start. This means the playground gives incorrect results compared to actual matching behavior (e.g. a pattern like `cover` would match `artwork/cover.jpg` in practice but not in the playground).
2. **Add tooltip** explaining the color scheme (red = no match, green = match, not preserved on exit)
3. **Short-circuit on empty regex** — avoid misleading all-green state when no pattern is configured
4. **Add placeholder text** — hints at expected input without needing the tooltip
5. **Simplify label text** — shorter and clearer wording
6. **Use interface_colors with alpha** — replaces bright `Qt.GlobalColor.green/red` with the existing `tagstatus_added`/`tagstatus_removed` colors at reduced opacity, matching the MetadataBox pattern and working well in both light and dark themes

<img width="1152" height="610" alt="image" src="https://github.com/user-attachments/assets/78a3a712-b2db-40be-abab-2106c6ead2da" />
