### PR TITLE
Review fixes for playground refactor

### DIFF
--- a/picard/coverart/providers/local.py
+++ b/picard/coverart/providers/local.py
@@ -76,7 +76,6 @@ class ProviderOptionsLocal(ProviderOptions):
         self.ui.test_coverart_filter.setPlaceholderText(_("Enter file names to test, one per line"))
         self.ui.test_coverart_filter.textChanged.connect(self._update_test_coverart_filter)
 
-        self.coverart_filter = None
         self.playground = Playground(self.ui.test_coverart_filter)
 
     def load(self):
@@ -88,18 +87,16 @@ class ProviderOptionsLocal(ProviderOptions):
         config.setting['local_cover_regex'] = self.ui.local_cover_regex_edit.text()
 
     def _update_test_coverart_filter(self):
-        def check_line(line: str) -> bool:
-            return bool(self.coverart_filter.search(line))
-
         regex_text = self.ui.local_cover_regex_edit.text()
         try:
-            self.coverart_filter = re.compile(regex_text, re.IGNORECASE) if regex_text else None
-            match_function = check_line if self.coverart_filter else None
+            coverart_filter = re.compile(regex_text, re.IGNORECASE) if regex_text else None
         except re.error:
-            self.coverart_filter = None
-            match_function = None
+            coverart_filter = None
 
-        self.playground.update(match_function)
+        def check_line(line: str) -> bool:
+            return bool(coverart_filter.search(line))
+
+        self.playground.update(check_line if coverart_filter else None)
 
 
 class CoverArtProviderLocal(CoverArtProvider):

--- a/picard/ui/playground.py
+++ b/picard/ui/playground.py
@@ -21,6 +21,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
+from collections.abc import Callable
+
 from PyQt6.QtGui import (
     QTextBlockFormat,
     QTextCursor,
@@ -68,11 +70,11 @@ class Playground:
         cursor.setBlockFormat(textformat)
         obj.blockSignals(False)
 
-    def update(self, match_function: callable = None) -> None:
+    def update(self, match_function: Callable[[str], bool] | None = None) -> None:
         """Update the playground widget to color-code each line depending on whether it passes the match function.
 
         Args:
-            match_function (callable): A function that takes a string and returns True if the string matches, otherwise False. Default is None.
+            match_function: A function that takes a string and returns True if the string matches, otherwise False. Default is None.
         """
         self._set_line_fmt(-1, self.fmt_clear)
 

--- a/picard/ui/playground.py
+++ b/picard/ui/playground.py
@@ -23,6 +23,7 @@
 
 from collections.abc import Callable
 
+from PyQt6.QtCore import QSignalBlocker
 from PyQt6.QtGui import (
     QTextBlockFormat,
     QTextCursor,
@@ -69,11 +70,8 @@ class Playground:
         return fmt
 
     def _set_line_fmt(self, lineno, textformat):
-        obj = self.playground_widget
-        cursor = QTextCursor(obj.document().findBlockByNumber(lineno))
-        obj.blockSignals(True)
+        cursor = QTextCursor(self.playground_widget.document().findBlockByNumber(lineno))
         cursor.setBlockFormat(textformat)
-        obj.blockSignals(False)
 
     def update(self, match_function: Callable[[str], bool] | None = None) -> None:
         """Update the playground widget to color-code each line depending on whether it passes the match function.
@@ -85,12 +83,13 @@ class Playground:
         fmt_skip = self._get_fmt_skip()
         fmt_clear = self._get_fmt_clear()
 
-        for lineno, line in enumerate(self.playground_widget.toPlainText().splitlines()):
-            line = line.strip()
-            if not line or match_function is None:
-                fmt = fmt_clear
-            elif match_function(line):
-                fmt = fmt_match
-            else:
-                fmt = fmt_skip
-            self._set_line_fmt(lineno, fmt)
+        with QSignalBlocker(self.playground_widget):
+            for lineno, line in enumerate(self.playground_widget.toPlainText().splitlines()):
+                line = line.strip()
+                if not line or match_function is None:
+                    fmt = fmt_clear
+                elif match_function(line):
+                    fmt = fmt_match
+                else:
+                    fmt = fmt_skip
+                self._set_line_fmt(lineno, fmt)

--- a/picard/ui/playground.py
+++ b/picard/ui/playground.py
@@ -43,15 +43,6 @@ class Playground:
         """
         self.playground_widget = playground_widget
 
-        self.fmt_match = QTextBlockFormat()
-        self.fmt_match.setBackground(self._highlight_color('tagstatus_added'))
-
-        self.fmt_skip = QTextBlockFormat()
-        self.fmt_skip.setBackground(self._highlight_color('tagstatus_removed'))
-
-        self.fmt_clear = QTextBlockFormat()
-        self.fmt_clear.clearBackground()
-
     @staticmethod
     def _highlight_color(color_key):
         alpha = 90 if interface_colors.dark_theme else 60
@@ -76,14 +67,23 @@ class Playground:
         Args:
             match_function: A function that takes a string and returns True if the string matches, otherwise False. Default is None.
         """
-        self._set_line_fmt(-1, self.fmt_clear)
+        fmt_match = QTextBlockFormat()
+        fmt_match.setBackground(self._highlight_color('tagstatus_added'))
+
+        fmt_skip = QTextBlockFormat()
+        fmt_skip.setBackground(self._highlight_color('tagstatus_removed'))
+
+        fmt_clear = QTextBlockFormat()
+        fmt_clear.clearBackground()
+
+        self._set_line_fmt(-1, fmt_clear)
 
         for lineno, line in enumerate(self.playground_widget.toPlainText().splitlines()):
             line = line.strip()
             if not line or match_function is None:
-                fmt = self.fmt_clear
+                fmt = fmt_clear
             elif match_function(line):
-                fmt = self.fmt_match
+                fmt = fmt_match
             else:
-                fmt = self.fmt_skip
+                fmt = fmt_skip
             self._set_line_fmt(lineno, fmt)

--- a/picard/ui/playground.py
+++ b/picard/ui/playground.py
@@ -50,6 +50,24 @@ class Playground:
         color.setAlpha(alpha)
         return color
 
+    def _get_fmt_match(self) -> QTextBlockFormat:
+        """Return the block format for matching lines."""
+        fmt = QTextBlockFormat()
+        fmt.setBackground(self._highlight_color('tagstatus_added'))
+        return fmt
+
+    def _get_fmt_skip(self) -> QTextBlockFormat:
+        """Return the block format for non-matching lines."""
+        fmt = QTextBlockFormat()
+        fmt.setBackground(self._highlight_color('tagstatus_removed'))
+        return fmt
+
+    def _get_fmt_clear(self) -> QTextBlockFormat:
+        """Return the block format for cleared (neutral) lines."""
+        fmt = QTextBlockFormat()
+        fmt.clearBackground()
+        return fmt
+
     def _set_line_fmt(self, lineno, textformat):
         obj = self.playground_widget
         if lineno < 0:
@@ -67,14 +85,9 @@ class Playground:
         Args:
             match_function: A function that takes a string and returns True if the string matches, otherwise False. Default is None.
         """
-        fmt_match = QTextBlockFormat()
-        fmt_match.setBackground(self._highlight_color('tagstatus_added'))
-
-        fmt_skip = QTextBlockFormat()
-        fmt_skip.setBackground(self._highlight_color('tagstatus_removed'))
-
-        fmt_clear = QTextBlockFormat()
-        fmt_clear.clearBackground()
+        fmt_match = self._get_fmt_match()
+        fmt_skip = self._get_fmt_skip()
+        fmt_clear = self._get_fmt_clear()
 
         self._set_line_fmt(-1, fmt_clear)
 

--- a/picard/ui/playground.py
+++ b/picard/ui/playground.py
@@ -70,11 +70,7 @@ class Playground:
 
     def _set_line_fmt(self, lineno, textformat):
         obj = self.playground_widget
-        if lineno < 0:
-            # use current cursor position
-            cursor = obj.textCursor()
-        else:
-            cursor = QTextCursor(obj.document().findBlockByNumber(lineno))
+        cursor = QTextCursor(obj.document().findBlockByNumber(lineno))
         obj.blockSignals(True)
         cursor.setBlockFormat(textformat)
         obj.blockSignals(False)
@@ -88,8 +84,6 @@ class Playground:
         fmt_match = self._get_fmt_match()
         fmt_skip = self._get_fmt_skip()
         fmt_clear = self._get_fmt_clear()
-
-        self._set_line_fmt(-1, fmt_clear)
 
         for lineno, line in enumerate(self.playground_widget.toPlainText().splitlines()):
             line = line.strip()

--- a/picard/ui/playground.py
+++ b/picard/ui/playground.py
@@ -78,15 +78,12 @@ class Playground:
         """
         self._set_line_fmt(-1, self.fmt_clear)
 
-        if match_function is None:
-            return
-
         for lineno, line in enumerate(self.playground_widget.toPlainText().splitlines()):
             line = line.strip()
-            fmt = self.fmt_clear
-            if line:
-                if match_function(line):
-                    fmt = self.fmt_match
-                else:
-                    fmt = self.fmt_skip
+            if not line or match_function is None:
+                fmt = self.fmt_clear
+            elif match_function(line):
+                fmt = self.fmt_match
+            else:
+                fmt = self.fmt_skip
             self._set_line_fmt(lineno, fmt)

--- a/test/test_ui_playground.py
+++ b/test/test_ui_playground.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+#
+# Picard, the next-generation MusicBrainz tagger
+#
+# Copyright (C) 2026 Laurent Monin
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import (
+    QColor,
+    QTextBlockFormat,
+    QTextCursor,
+)
+from PyQt6.QtWidgets import QPlainTextEdit
+
+import pytest
+
+from picard.ui.playground import Playground
+
+
+MATCH_COLOR = QColor(0, 255, 0)
+SKIP_COLOR = QColor(255, 0, 0)
+
+
+class MockPlayground(Playground):
+    """Playground subclass with deterministic colors for testing."""
+
+    def _get_fmt_match(self):
+        fmt = QTextBlockFormat()
+        fmt.setBackground(MATCH_COLOR)
+        return fmt
+
+    def _get_fmt_skip(self):
+        fmt = QTextBlockFormat()
+        fmt.setBackground(SKIP_COLOR)
+        return fmt
+
+
+@pytest.fixture()
+def playground_widget(qapp):
+    widget = QPlainTextEdit()
+    widget.setPlainText("foo\nbar\nbaz\n")
+    return widget
+
+
+@pytest.fixture()
+def playground(playground_widget):
+    return MockPlayground(playground_widget)
+
+
+def _get_block_background(widget, lineno):
+    """Get the background color of a specific block (line) in the widget."""
+    block = widget.document().findBlockByNumber(lineno)
+    cursor = QTextCursor(block)
+    return cursor.blockFormat().background().color()
+
+
+def _has_background(widget, lineno):
+    """Check if a specific block has a non-default background set."""
+    block = widget.document().findBlockByNumber(lineno)
+    cursor = QTextCursor(block)
+    return cursor.blockFormat().background().style() != Qt.BrushStyle.NoBrush
+
+
+class TestPlayground:
+    def test_update_with_none_clears_all_lines(self, playground, playground_widget):
+        """When match_function is None, all lines should have no background."""
+        # First apply some coloring
+        playground.update(lambda line: line == "foo")
+        assert _has_background(playground_widget, 0)
+
+        # Now clear with None
+        playground.update(None)
+        for lineno in range(3):
+            assert not _has_background(playground_widget, lineno)
+
+    def test_update_matching_lines_get_match_color(self, playground, playground_widget):
+        """Lines that match should get the match color."""
+        playground.update(lambda line: line == "foo")
+        assert _get_block_background(playground_widget, 0) == MATCH_COLOR
+
+    def test_update_non_matching_lines_get_skip_color(self, playground, playground_widget):
+        """Lines that don't match should get the skip color."""
+        playground.update(lambda line: line == "foo")
+        assert _get_block_background(playground_widget, 1) == SKIP_COLOR
+
+    def test_update_empty_lines_get_cleared(self, playground_widget):
+        """Empty lines should always get cleared regardless of match function."""
+        playground_widget.setPlainText("foo\n\nbaz")
+        playground = MockPlayground(playground_widget)
+        playground.update(lambda line: True)
+        assert not _has_background(playground_widget, 1)
+        assert _has_background(playground_widget, 0)
+        assert _has_background(playground_widget, 2)
+
+    def test_update_whitespace_only_lines_treated_as_empty(self, playground_widget):
+        """Lines with only whitespace should be treated as empty."""
+        playground_widget.setPlainText("foo\n   \nbaz")
+        playground = MockPlayground(playground_widget)
+        playground.update(lambda line: True)
+        assert not _has_background(playground_widget, 1)
+
+    def test_update_all_match(self, playground, playground_widget):
+        """When all lines match, they should all get the match color."""
+        playground.update(lambda line: True)
+        for lineno in range(3):
+            assert _get_block_background(playground_widget, lineno) == MATCH_COLOR
+
+    def test_update_none_match(self, playground, playground_widget):
+        """When no lines match, they should all get the skip color."""
+        playground.update(lambda line: False)
+        for lineno in range(3):
+            assert _get_block_background(playground_widget, lineno) == SKIP_COLOR
+
+    def test_signals_not_emitted_during_update(self, playground, playground_widget):
+        """The update should block signals to avoid recursive textChanged triggers."""
+        signal_count = []
+
+        def on_text_changed():
+            signal_count.append(1)
+
+        playground_widget.textChanged.connect(on_text_changed)
+        playground.update(lambda line: True)
+        assert len(signal_count) == 0


### PR DESCRIPTION
## Summary

Review fixes for PR metabrainz/picard#3318.

## Changes

1. **Use proper Callable type hint** — Replace `callable` (a builtin function) with `Callable[[str], bool] | None` from `collections.abc`
2. **Remove unnecessary instance state** — `self.coverart_filter` in local.py replaced with a local variable captured by the closure (matching genres.py pattern)
3. **Fix stale highlight colors** — When match_function is None, all lines are now properly cleared instead of only the cursor's current line
4. **Resolve colors at update time** — Colors are computed on each `update()` call instead of cached at `__init__`, so theme changes are handled correctly
5. **Extract format creation into overridable methods** — `_get_fmt_match()`, `_get_fmt_skip()`, `_get_fmt_clear()` can be overridden by subclasses/tests
6. **Remove redundant cursor-position clear** — The loop handles all lines, so the initial `_set_line_fmt(-1, fmt_clear)` was unnecessary
7. **Use QSignalBlocker context manager** — Block signals once around the entire loop instead of per-line; exception-safe and cleaner

Also adds `test/test_ui_playground.py` with 8 tests covering all update() behaviors.